### PR TITLE
"downpayment too small" bug fixed

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -242,6 +242,7 @@ RegisterNetEvent('qb-vehicleshop:server:financeVehicle', function(downPayment, p
     local vehiclePrice = QBCore.Shared.Vehicles[vehicle]['price']
     local timer = (Config.PaymentInterval * 60)
     local minDown = tonumber(round((Config.MinimumDown / 100) * vehiclePrice))
+    downPayment = tonumber(round(((downPayment / 100) * vehiclePrice)))
     if downPayment > vehiclePrice then return TriggerClientEvent('QBCore:Notify', src, Lang:t('error.notworth'), 'error') end
     if downPayment < minDown then return TriggerClientEvent('QBCore:Notify', src, Lang:t('error.downtoosmall'), 'error') end
     if paymentAmount > Config.MaximumPayments then return TriggerClientEvent('QBCore:Notify', src, Lang:t('error.exceededmax'), 'error') end


### PR DESCRIPTION
Before, the bug would occur because downpayment (a percentage) was being compared with the dollar value. e.g. 10% < 14500$

Now I added 1 line to change the percentage into the dollar value of the downpayment so that the checks in the lines below are correct.

I checked that the database is updated correctly and everything was correct, so I will assume the remaining payments are also taken correctly.