### PR TITLE
Fix exploitable events

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -12,8 +12,7 @@ local insideShop, tempShop = nil, nil
 -- Handlers
 AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
     PlayerData = QBCore.Functions.GetPlayerData()
-    local citizenid = PlayerData.citizenid
-    TriggerServerEvent('qb-vehicleshop:server:addPlayer', citizenid)
+    TriggerServerEvent('qb-vehicleshop:server:addPlayer')
     TriggerServerEvent('qb-vehicleshop:server:checkFinance')
     if not Initialized then Init() end
 end)
@@ -24,8 +23,7 @@ AddEventHandler('onResourceStart', function(resource)
     end
     if next(PlayerData) ~= nil and not Initialized then
         PlayerData = QBCore.Functions.GetPlayerData()
-        local citizenid = PlayerData.citizenid
-        TriggerServerEvent('qb-vehicleshop:server:addPlayer', citizenid)
+        TriggerServerEvent('qb-vehicleshop:server:addPlayer')
         TriggerServerEvent('qb-vehicleshop:server:checkFinance')
         Init()
     end

--- a/server.lua
+++ b/server.lua
@@ -106,8 +106,11 @@ end)
 
 -- Brute force vehicle deletion
 RegisterNetEvent('qb-vehicleshop:server:deleteVehicle', function(netId)
+    local src = tonumber(source)
     local vehicle = NetworkGetEntityFromNetworkId(netId)
-    DeleteEntity(vehicle)
+    if DoesEntityExist(vehicle) and NetworkGetEntityOwner(vehicle) == src then
+        DeleteEntity(vehicle)
+    end
 end)
 
 -- Sync vehicle for other players

--- a/server.lua
+++ b/server.lua
@@ -4,8 +4,11 @@ local financetimer = {}
 
 -- Handlers
 -- Store game time for player when they load
-RegisterNetEvent('qb-vehicleshop:server:addPlayer', function(citizenid)
-    financetimer[citizenid] = os.time()
+RegisterNetEvent('qb-vehicleshop:server:addPlayer', function()
+    local src = tonumber(source)
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not Player then return end
+    financetimer[Player.PlayerData.citizenid] = os.time()
 end)
 
 -- Deduct stored game time from player on logout


### PR DESCRIPTION
**Describe Pull request**

- Fixes the `qb-vehicleshop:server:deleteVehicle` net event by preventing deletion of any networked entity.
- Fixes potential abuse of the `financetimer` logic by removing the `citizenid` parameter and stopping relying on the client.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality?
--> Yes, but please make sure you do as well, just to be extra sure this works as intended!

- Does your code fit the style guidelines?
--> Yes, I think so.

- Does your PR fit the contribution guidelines?
--> Yes, I think so as well.
