### PR TITLE
feat/fix: dynamic showroom fallback and server cache refresh

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -933,3 +933,23 @@ CreateThread(function()
         end
     end
 end)
+
+-- Update the showroom physically when a vehicle is dynamically removed
+RegisterNetEvent('qb-vehicleshop:client:ReplaceDeletedVehicle', function(shopName, deletedModel, replacement)
+    if not Config.Shops[shopName] then return end
+    
+    for i, vehData in ipairs(Config.Shops[shopName]['ShowroomVehicles']) do
+        if vehData.defaultVehicle == deletedModel then
+            vehData.defaultVehicle = replacement
+        end
+        
+        if vehData.chosenVehicle == deletedModel then
+            local swapData = {
+                ClosestShop = shopName,
+                ClosestVehicle = i,
+                toVehicle = replacement
+            }
+            TriggerEvent('qb-vehicleshop:client:swapVehicle', swapData)
+        end
+    end
+end)

--- a/client.lua
+++ b/client.lua
@@ -136,15 +136,21 @@ local function comma_value(amount)
 end
 
 local function getVehName()
-    return sharedVehicles[Config.Shops[insideShop]['ShowroomVehicles'][ClosestVehicle].chosenVehicle]['name']
+    local chosen = Config.Shops[insideShop] and Config.Shops[insideShop]['ShowroomVehicles'] and Config.Shops[insideShop]['ShowroomVehicles'][ClosestVehicle] and Config.Shops[insideShop]['ShowroomVehicles'][ClosestVehicle].chosenVehicle
+    local veh = chosen and sharedVehicles[chosen]
+    return veh and veh['name'] or tostring(chosen or "Unknown")
 end
 
 local function getVehPrice()
-    return comma_value(sharedVehicles[Config.Shops[insideShop]['ShowroomVehicles'][ClosestVehicle].chosenVehicle]['price'])
+    local chosen = Config.Shops[insideShop] and Config.Shops[insideShop]['ShowroomVehicles'] and Config.Shops[insideShop]['ShowroomVehicles'][ClosestVehicle] and Config.Shops[insideShop]['ShowroomVehicles'][ClosestVehicle].chosenVehicle
+    local veh = chosen and sharedVehicles[chosen]
+    return veh and comma_value(veh['price']) or "0"
 end
 
 local function getVehBrand()
-    return sharedVehicles[Config.Shops[insideShop]['ShowroomVehicles'][ClosestVehicle].chosenVehicle]['brand']
+    local chosen = Config.Shops[insideShop] and Config.Shops[insideShop]['ShowroomVehicles'] and Config.Shops[insideShop]['ShowroomVehicles'][ClosestVehicle] and Config.Shops[insideShop]['ShowroomVehicles'][ClosestVehicle].chosenVehicle
+    local veh = chosen and sharedVehicles[chosen]
+    return veh and veh['brand'] or ""
 end
 
 local function setClosestShowroomVehicle()
@@ -795,7 +801,7 @@ RegisterNetEvent('qb-vehicleshop:client:getVehicles', function()
         local ownedVehicles = {}
         for _, v in pairs(vehicles) do
             local vehData = sharedVehicles[v.vehicle]
-            if v.balance ~= 0 and vehData.shop == insideShop then
+            if vehData and v.balance ~= 0 and vehData.shop == insideShop then
                 local plate = v.plate:upper()
                 ownedVehicles[#ownedVehicles + 1] = {
                     header = vehData.name,
@@ -895,8 +901,12 @@ RegisterNetEvent('qb-vehicleshop:client:financePayment', function(data)
 end)
 
 RegisterNetEvent('qb-vehicleshop:client:openIdMenu', function(data)
+    local header = data.vehicle
+    if sharedVehicles[data.vehicle] then
+        header = sharedVehicles[data.vehicle]['name']
+    end
     local dialog = exports['qb-input']:ShowInput({
-        header = sharedVehicles[data.vehicle]['name'],
+        header = header,
         submitText = Lang:t('menus.submit_text'),
         inputs = {
             {

--- a/client.lua
+++ b/client.lua
@@ -426,6 +426,63 @@ end
 
 function Init()
     Initialized = true
+
+    -- Filter out deleted/invalid showroom vehicles before spawning them
+    local currentVehicles = exports['qb-core']:GetShared('Vehicles') or sharedVehicles
+    if currentVehicles and next(currentVehicles) then
+        for shopName, shop in pairs(Config.Shops) do
+            if shop['ShowroomVehicles'] then
+                for i = 1, #shop['ShowroomVehicles'] do
+                    local defaultModel = shop['ShowroomVehicles'][i].defaultVehicle
+                    local chosenModel = shop['ShowroomVehicles'][i].chosenVehicle
+                    
+                    local defaultInvalid = not defaultModel or not currentVehicles[defaultModel] or not next(currentVehicles[defaultModel])
+                    local chosenInvalid = not chosenModel or not currentVehicles[chosenModel] or not next(currentVehicles[chosenModel])
+                    
+                    if defaultInvalid or chosenInvalid then
+                        local replacement = nil
+                        local fallbackPool = {}
+                        
+                        for model, vehicle in pairs(currentVehicles) do
+                            local shops = type(vehicle.shop) == 'table' and vehicle.shop or { vehicle.shop }
+                            local belongsToShop = false
+                            for _, sName in ipairs(shops) do
+                                if sName == shopName then
+                                    belongsToShop = true
+                                    break
+                                end
+                            end
+                            if belongsToShop then
+                                table.insert(fallbackPool, model)
+                            end
+                        end
+                        
+                        if #fallbackPool > 0 then
+                            replacement = fallbackPool[math.random(1, #fallbackPool)]
+                        else
+                            local genericPool = {}
+                            for model in pairs(currentVehicles) do
+                                table.insert(genericPool, model)
+                            end
+                            if #genericPool > 0 then
+                                replacement = genericPool[math.random(1, #genericPool)]
+                            end
+                        end
+                        
+                        if replacement then
+                            if defaultInvalid then
+                                shop['ShowroomVehicles'][i].defaultVehicle = replacement
+                            end
+                            if chosenInvalid then
+                                shop['ShowroomVehicles'][i].chosenVehicle = replacement
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
     CreateThread(function()
         for name, shop in pairs(Config.Shops) do
             if shop['Type'] == 'free-use' then

--- a/server.lua
+++ b/server.lua
@@ -553,15 +553,6 @@ QBCore.Commands.Add('transfervehicle', Lang:t('general.command_transfervehicle')
     end
 end)
 
--- Helper to check if a value exists in a table (useful for shop arrays)
-local function hasValue(tbl, val)
-    if type(tbl) ~= "table" then return false end
-    for _, v in pairs(tbl) do
-        if v == val then return true end
-    end
-    return false
-end
-
 -- Dynamically update showrooms if a vehicle gets removed from QBCore.Shared.Vehicles (Server-Side Only for Security)
 AddEventHandler('qb-vehicleshop:server:UpdateShowroomAfterDeletion', function(deletedModel, deletedCategory)
     local currentVehicles = exports['qb-core']:GetShared('Vehicles')

--- a/server.lua
+++ b/server.lua
@@ -55,6 +55,13 @@ QBCore.Functions.CreateCallback('qb-vehicleshop:server:spawnvehicle', function(s
 end)
 
 -- Handlers
+
+-- Update server-side cached variables when QBCore objects are updated dynamically
+AddEventHandler('QBCore:Server:UpdateObject', function()
+    QBCore = exports['qb-core']:GetCoreObject({ 'Functions', 'Commands' })
+    sharedVehicles = exports['qb-core']:GetShared('Vehicles')
+end)
+
 -- Store game time for player when they load
 RegisterNetEvent('qb-vehicleshop:server:addPlayer', function(citizenid)
     financetimer[citizenid] = os.time()

--- a/server.lua
+++ b/server.lua
@@ -270,6 +270,7 @@ RegisterNetEvent('qb-vehicleshop:server:buyShowroomVehicle', function(vehicle)
         TriggerClientEvent('QBCore:Notify', src, Lang:t('success.purchased'), 'success')
         TriggerClientEvent('qb-vehicleshop:client:buyShowroomVehicle', src, vehicle, plate)
         pData.Functions.RemoveMoney('cash', vehiclePrice, 'vehicle-bought-in-showroom')
+        TriggerEvent('qb-vehicleshop:server:onVehiclePurchased', cid, vehicle, plate)
     elseif bank > tonumber(vehiclePrice) then
         MySQL.insert('INSERT INTO player_vehicles (license, citizenid, vehicle, hash, mods, plate, garage, state) VALUES (?, ?, ?, ?, ?, ?, ?, ?)', {
             pData.PlayerData.license,
@@ -284,6 +285,7 @@ RegisterNetEvent('qb-vehicleshop:server:buyShowroomVehicle', function(vehicle)
         TriggerClientEvent('QBCore:Notify', src, Lang:t('success.purchased'), 'success')
         TriggerClientEvent('qb-vehicleshop:client:buyShowroomVehicle', src, vehicle, plate)
         pData.Functions.RemoveMoney('bank', vehiclePrice, 'vehicle-bought-in-showroom')
+        TriggerEvent('qb-vehicleshop:server:onVehiclePurchased', cid, vehicle, plate)
     else
         TriggerClientEvent('QBCore:Notify', src, Lang:t('error.notenoughmoney'), 'error')
     end
@@ -324,6 +326,7 @@ RegisterNetEvent('qb-vehicleshop:server:financeVehicle', function(downPayment, p
         TriggerClientEvent('QBCore:Notify', src, Lang:t('success.purchased'), 'success')
         TriggerClientEvent('qb-vehicleshop:client:buyShowroomVehicle', src, vehicle, plate)
         pData.Functions.RemoveMoney('cash', downPayment, 'vehicle-bought-in-showroom')
+        TriggerEvent('qb-vehicleshop:server:onVehiclePurchased', cid, vehicle, plate)
     elseif bank >= downPayment then
         MySQL.insert('INSERT INTO player_vehicles (license, citizenid, vehicle, hash, mods, plate, garage, state, balance, paymentamount, paymentsleft, financetime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', {
             pData.PlayerData.license,
@@ -342,6 +345,7 @@ RegisterNetEvent('qb-vehicleshop:server:financeVehicle', function(downPayment, p
         TriggerClientEvent('QBCore:Notify', src, Lang:t('success.purchased'), 'success')
         TriggerClientEvent('qb-vehicleshop:client:buyShowroomVehicle', src, vehicle, plate)
         pData.Functions.RemoveMoney('bank', downPayment, 'vehicle-bought-in-showroom')
+        TriggerEvent('qb-vehicleshop:server:onVehiclePurchased', cid, vehicle, plate)
     else
         TriggerClientEvent('QBCore:Notify', src, Lang:t('error.notenoughmoney'), 'error')
     end
@@ -383,6 +387,7 @@ RegisterNetEvent('qb-vehicleshop:server:sellShowroomVehicle', function(data, pla
             TriggerClientEvent('QBCore:Notify', src, Lang:t('success.earned_commission', { amount = comma_value(commission) }), 'success')
             exports['qb-banking']:AddMoney(player.PlayerData.job.name, vehiclePrice, 'Vehicle sale')
             TriggerClientEvent('QBCore:Notify', target.PlayerData.source, Lang:t('success.purchased'), 'success')
+            TriggerEvent('qb-vehicleshop:server:onVehiclePurchased', cid, vehicle, plate)
         elseif bank >= tonumber(vehiclePrice) then
             MySQL.insert('INSERT INTO player_vehicles (license, citizenid, vehicle, hash, mods, plate, garage, state) VALUES (?, ?, ?, ?, ?, ?, ?, ?)', {
                 target.PlayerData.license,
@@ -400,6 +405,7 @@ RegisterNetEvent('qb-vehicleshop:server:sellShowroomVehicle', function(data, pla
             exports['qb-banking']:AddMoney(player.PlayerData.job.name, vehiclePrice, 'Vehicle sale')
             TriggerClientEvent('QBCore:Notify', src, Lang:t('success.earned_commission', { amount = comma_value(commission) }), 'success')
             TriggerClientEvent('QBCore:Notify', target.PlayerData.source, Lang:t('success.purchased'), 'success')
+            TriggerEvent('qb-vehicleshop:server:onVehiclePurchased', cid, vehicle, plate)
         else
             TriggerClientEvent('QBCore:Notify', src, Lang:t('error.notenoughmoney'), 'error')
         end
@@ -455,6 +461,7 @@ RegisterNetEvent('qb-vehicleshop:server:sellfinanceVehicle', function(downPaymen
             TriggerClientEvent('QBCore:Notify', src, Lang:t('success.earned_commission', { amount = comma_value(commission) }), 'success')
             exports['qb-banking']:AddMoney(player.PlayerData.job.name, vehiclePrice, 'Vehicle sale')
             TriggerClientEvent('QBCore:Notify', target.PlayerData.source, Lang:t('success.purchased'), 'success')
+            TriggerEvent('qb-vehicleshop:server:onVehiclePurchased', cid, vehicle, plate)
         elseif bank >= downPayment then
             MySQL.insert('INSERT INTO player_vehicles (license, citizenid, vehicle, hash, mods, plate, garage, state, balance, paymentamount, paymentsleft, financetime) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', {
                 target.PlayerData.license,
@@ -476,6 +483,7 @@ RegisterNetEvent('qb-vehicleshop:server:sellfinanceVehicle', function(downPaymen
             TriggerClientEvent('QBCore:Notify', src, Lang:t('success.earned_commission', { amount = comma_value(commission) }), 'success')
             exports['qb-banking']:AddMoney(player.PlayerData.job.name, vehiclePrice, 'Vehicle sale')
             TriggerClientEvent('QBCore:Notify', target.PlayerData.source, Lang:t('success.purchased'), 'success')
+            TriggerEvent('qb-vehicleshop:server:onVehiclePurchased', cid, vehicle, plate)
         else
             TriggerClientEvent('QBCore:Notify', src, Lang:t('error.notenoughmoney'), 'error')
         end

--- a/server.lua
+++ b/server.lua
@@ -562,26 +562,37 @@ local function hasValue(tbl, val)
     return false
 end
 
--- Dynamically update showrooms if a vehicle gets removed from QBCore.Shared.Vehicles
-RegisterNetEvent('qb-vehicleshop:server:UpdateShowroomAfterDeletion', function(deletedModel, deletedCategory)
+-- Dynamically update showrooms if a vehicle gets removed from QBCore.Shared.Vehicles (Server-Side Only for Security)
+AddEventHandler('qb-vehicleshop:server:UpdateShowroomAfterDeletion', function(deletedModel, deletedCategory)
     local currentVehicles = exports['qb-core']:GetShared('Vehicles')
-    
-    for shopName, _ in pairs(Config.Shops) do
-        local replacement = nil
-        local sameCatPool = {}
-        local fallbackPool = {}
-        
-        for k, v in pairs(currentVehicles) do
-            if k ~= deletedModel then
-                local inShop = (v.shop == shopName) or (type(v.shop) == "table" and hasValue(v.shop, shopName))
-                if inShop then
-                    fallbackPool[#fallbackPool + 1] = k
-                    if v.category == deletedCategory then
-                        sameCatPool[#sameCatPool + 1] = k
-                    end
+    local shopPools = {}
+
+    -- Pre-index pools for performance (O(N) instead of O(N^2))
+    for shopName in pairs(Config.Shops) do
+        shopPools[shopName] = { fallbackPool = {}, categoryPools = {} }
+    end
+
+    for model, vehicle in pairs(currentVehicles) do
+        if model ~= deletedModel then
+            local shops = type(vehicle.shop) == 'table' and vehicle.shop or { vehicle.shop }
+            
+            for _, shopName in ipairs(shops) do
+                local pool = shopPools[shopName]
+                if pool then
+                    pool.fallbackPool[#pool.fallbackPool + 1] = model
+                    local category = vehicle.category
+                    if not pool.categoryPools[category] then pool.categoryPools[category] = {} end
+                    pool.categoryPools[category][#pool.categoryPools[category] + 1] = model
                 end
             end
         end
+    end
+
+    for shopName in pairs(Config.Shops) do
+        local replacement = nil
+        local pool = shopPools[shopName]
+        local sameCatPool = pool.categoryPools[deletedCategory] or {}
+        local fallbackPool = pool.fallbackPool
         
         -- Prioritize same category, fallback to any vehicle in the shop
         if #sameCatPool > 0 then

--- a/server.lua
+++ b/server.lua
@@ -566,7 +566,7 @@ end
 RegisterNetEvent('qb-vehicleshop:server:UpdateShowroomAfterDeletion', function(deletedModel, deletedCategory)
     local currentVehicles = exports['qb-core']:GetShared('Vehicles')
     
-    for shopName, shopData in pairs(Config.Shops) do
+    for shopName, _ in pairs(Config.Shops) do
         local replacement = nil
         local sameCatPool = {}
         local fallbackPool = {}

--- a/server.lua
+++ b/server.lua
@@ -545,3 +545,46 @@ QBCore.Commands.Add('transfervehicle', Lang:t('general.command_transfervehicle')
         TriggerClientEvent('QBCore:Notify', src, Lang:t('error.buyertoopoor'), 'error')
     end
 end)
+
+-- Helper to check if a value exists in a table (useful for shop arrays)
+local function hasValue(tbl, val)
+    if type(tbl) ~= "table" then return false end
+    for _, v in pairs(tbl) do
+        if v == val then return true end
+    end
+    return false
+end
+
+-- Dynamically update showrooms if a vehicle gets removed from QBCore.Shared.Vehicles
+RegisterNetEvent('qb-vehicleshop:server:UpdateShowroomAfterDeletion', function(deletedModel, deletedCategory)
+    local currentVehicles = exports['qb-core']:GetShared('Vehicles')
+    
+    for shopName, shopData in pairs(Config.Shops) do
+        local replacement = nil
+        local sameCatPool = {}
+        local fallbackPool = {}
+        
+        for k, v in pairs(currentVehicles) do
+            if k ~= deletedModel then
+                local inShop = (v.shop == shopName) or (type(v.shop) == "table" and hasValue(v.shop, shopName))
+                if inShop then
+                    fallbackPool[#fallbackPool + 1] = k
+                    if v.category == deletedCategory then
+                        sameCatPool[#sameCatPool + 1] = k
+                    end
+                end
+            end
+        end
+        
+        -- Prioritize same category, fallback to any vehicle in the shop
+        if #sameCatPool > 0 then
+            replacement = sameCatPool[math.random(1, #sameCatPool)]
+        elseif #fallbackPool > 0 then
+            replacement = fallbackPool[math.random(1, #fallbackPool)]
+        end
+        
+        if replacement then
+            TriggerClientEvent('qb-vehicleshop:client:ReplaceDeletedVehicle', -1, shopName, deletedModel, replacement)
+        end
+    end
+end)


### PR DESCRIPTION
**Describe Pull request**
This PR fixes an issue with server-side pricing cache and adds a fallback mechanism for dynamically removed showroom vehicles.

1. **Server Cache Refresh (`fix`)**: 
Currently, `sharedVehicles` is only fetched on resource start. If a vehicle's data (like price) is updated dynamically in `QBCore.Shared.Vehicles` during runtime, the client UI updates, but the server still charges the old cached price. Added an event handler for `QBCore:Server:UpdateObject` to keep the server-side cache perfectly synced.

2. **Dynamic Showroom Fallback (`feat`)**: 
Removing a vehicle from `QBCore.Shared.Vehicles` dynamically leaves a broken/invisible entity in the showroom. Added a new global event (`qb-vehicleshop:server:UpdateShowroomAfterDeletion`). External resources can trigger this before removing a vehicle to gracefully replace it in the showroom (prioritizing the same category, or falling back to a random vehicle in that shop).

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]